### PR TITLE
Switch barcodecop to use the biocontainers base image

### DIFF
--- a/barcodecop/v0.4.1/Dockerfile
+++ b/barcodecop/v0.4.1/Dockerfile
@@ -1,13 +1,18 @@
 # barcodecop
 #
-# VERSION               0.4.1
+# VERSION               0.4.1A
 
-FROM      alpine:3.7
+FROM biocontainers/biocontainers:v1.1.0_cv2
+USER root
 RUN mkdir /fh && mkdir /app && mkdir /src
 RUN mkdir -p /mnt/inputs/file && mkdir -p /mnt/outputs/file && mkdir /scratch && mkdir /working
-RUN apk add --no-cache  bash \
-python3==3.6.3-r9
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip && \
+    apt-get clean && \
+    apt-get purge && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN ln -s /usr/bin/python3 /usr/local/bin/python
+USER biodocker
 RUN pip3 install \
 awscli>=1.15.14 \
 boto3>=1.7.14 \


### PR DESCRIPTION
Was able to build locally.

Outstanding question -- which Dockerfile do you want to use for this tool, @jgolob? There are two in the folder, and I picked the one which I thought was being used for `geneshot`, even though the version number was lower.